### PR TITLE
Fix/column names/richard

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,6 @@ class UsersController < ApplicationController
               private
         
               def user_params
-                params.permit( :full_name,:email,:licence_number,:contact,:experience, :password,  :password_confirmation)
+                params.permit( :full_name,:email,:license_number,:contact,:experience, :password,  :password_confirmation)
               end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
 class User < ApplicationRecord
     has_secure_password
+
+    validates :email, :full_name, :license_number, presence: true
+    validates :email, uniqueness: true
 end

--- a/db/migrate/20221013073249_fix_users_columns_name.rb
+++ b/db/migrate/20221013073249_fix_users_columns_name.rb
@@ -1,0 +1,5 @@
+class FixUsersColumnsName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :licence_number, :license_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_12_142728) do
+ActiveRecord::Schema.define(version: 2022_10_13_073249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2022_10_12_142728) do
   create_table "users", force: :cascade do |t|
     t.string "full_name"
     t.string "email"
-    t.string "licence_number"
+    t.string "license_number"
     t.integer "contact"
     t.integer "experience"
     t.string "password_digest"


### PR DESCRIPTION
Changed column name on users table: licence_number to license_number.
Added validations for fullname, email and license number to be present, and email must be unique.